### PR TITLE
Improve UX by adding status messages when starting an operation

### DIFF
--- a/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/CustomAttributesViewController.swift
+++ b/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/CustomAttributesViewController.swift
@@ -76,6 +76,8 @@ class CustomAttributesViewController: UIViewController {
 
         print("Signing up with email \(email), password and attributes: \(attributes)")
 
+        showResultText("Signing up...")
+
         nativeAuth.signUp(username: email,
                           password: password,
                           attributes: attributes,

--- a/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/EmailAndCodeViewController.swift
+++ b/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/EmailAndCodeViewController.swift
@@ -69,6 +69,8 @@ class EmailAndCodeViewController: UIViewController {
 
         print("Signing up with email \(email)")
 
+        showResultText("Signing up...")
+
         nativeAuth.signUp(username: email, delegate: self)
     }
 
@@ -79,6 +81,8 @@ class EmailAndCodeViewController: UIViewController {
         }
 
         print("Signing in with email \(email)")
+
+        showResultText("Signing in...")
 
         nativeAuth.signIn(username: email, delegate: self)
     }

--- a/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/EmailAndPasswordViewController.swift
+++ b/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/EmailAndPasswordViewController.swift
@@ -69,6 +69,8 @@ class EmailAndPasswordViewController: UIViewController {
 
         print("Signing up with email \(email) and password")
 
+        showResultText("Signing up...")
+
         nativeAuth.signUp(username: email, password: password, delegate: self)
     }
 
@@ -79,6 +81,8 @@ class EmailAndPasswordViewController: UIViewController {
         }
 
         print("Signing in with email \(email) and password")
+
+        showResultText("Signing in...")
 
         nativeAuth.signIn(username: email, password: password, delegate: self)
     }

--- a/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/ObjCViewController.m
+++ b/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/ObjCViewController.m
@@ -66,6 +66,8 @@
     NSString *email = self.emailTextField.text;
     NSString *password = self.passwordTextField.text;
 
+    [self showResultText:@"Signing in..."];
+
     [self.nativeAuth signInUsername:email
                            password:password
                              scopes:nil

--- a/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/ProtectedAPIViewController.swift
+++ b/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/ProtectedAPIViewController.swift
@@ -74,6 +74,8 @@ class ProtectedAPIViewController: UIViewController {
 
         print("Signing in with email \(email) and password")
 
+        showResultText("Signing in...")
+
         nativeAuth.signIn(username: email, password: password, scopes: protectedAPIScopes, delegate: self)
     }
 

--- a/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/ResetPasswordViewController.swift
+++ b/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/ResetPasswordViewController.swift
@@ -69,7 +69,7 @@ class ResetPasswordViewController: UIViewController {
 
         print("Resetting password for email \(email)")
 
-        showResultText("")
+        showResultText("Resetting password...")
 
         nativeAuth.resetPassword(username: email, delegate: self)
     }

--- a/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/WebFallbackViewController.swift
+++ b/native-authentication/NativeAuthSampleApp/NativeAuthSampleApp/WebFallbackViewController.swift
@@ -66,6 +66,8 @@ class WebFallbackViewController: UIViewController {
 
         print("Signing in with email \(email) and password")
 
+        showResultText("Signing in...")
+
         nativeAuth.signIn(username: email, password: password, delegate: self)
     }
 


### PR DESCRIPTION
## Purpose

This PR improves the UX of the sample app by displaying a simple status message before starting an operation, e.g. "Signing up...".  Once the operation completes this message will be replaced with the final status message, e.g. "Signed up successfully" or "Error signing up: Password invalid". 

This is a small change but makes a difference, especially since we don't have any other way of showing that an operation is in progress.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```



## How to Test

Run the sample app
![CleanShot 2024-01-31 at 15 47 48](https://github.com/Azure-Samples/ms-identity-ciam-native-auth-ios-sample/assets/110929942/5a714939-8559-434c-ac6f-187bcf32a400)

