### PR TITLE
Hide Keyboard after action in VerifyViewController

### DIFF
--- a/NativeAuthSampleApp/Base.lproj/Main.storyboard
+++ b/NativeAuthSampleApp/Base.lproj/Main.storyboard
@@ -291,42 +291,42 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="11" translatesAutoresizingMaskIntoConstraints="NO" id="NPF-eL-qXI" userLabel="Fields Stack View">
-                                        <rect key="frame" x="0.0" y="77.666666666666643" width="353" height="243.33333333333337"/>
+                                        <rect key="frame" x="0.0" y="77.666666666666657" width="353" height="270"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="53" translatesAutoresizingMaskIntoConstraints="NO" id="vbw-VI-BCB">
-                                                <rect key="frame" x="0.0" y="0.0" width="353" height="40"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="353" height="45.333333333333336"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Email" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cEI-M0-cGq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="40.666666666666664" height="40"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="40.666666666666664" height="45.333333333333336"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bcI-75-H9s">
-                                                        <rect key="frame" x="93.666666666666657" y="0.0" width="259.33333333333337" height="40"/>
+                                                        <rect key="frame" x="93.666666666666657" y="0.0" width="259.33333333333337" height="45.333333333333336"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" autocorrectionType="no" keyboardType="emailAddress" textContentType="email"/>
                                                     </textField>
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="VwC-eu-ShE">
-                                                <rect key="frame" x="0.0" y="51" width="353" height="39.666666666666657"/>
+                                                <rect key="frame" x="0.0" y="56.333333333333343" width="353" height="45"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Password" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MJN-MK-hLq">
-                                                        <rect key="frame" x="0.0" y="0.0" width="73.333333333333329" height="39.666666666666664"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="73.333333333333329" height="45"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="jRP-EZ-IgC">
-                                                        <rect key="frame" x="93.333333333333343" y="0.0" width="259.66666666666663" height="39.666666666666664"/>
+                                                        <rect key="frame" x="93.333333333333343" y="0.0" width="259.66666666666663" height="45"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" secureTextEntry="YES" textContentType="password"/>
                                                     </textField>
                                                 </subviews>
                                             </stackView>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LEx-eT-bcY">
-                                                <rect key="frame" x="0.0" y="101.66666666666669" width="353" height="40"/>
+                                                <rect key="frame" x="0.0" y="112.33333333333333" width="353" height="45.333333333333329"/>
                                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="27.333333333333336" id="vTh-9h-DnR"/>
@@ -337,13 +337,13 @@
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Country" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3F9-A2-B8u">
-                                                        <rect key="frame" x="0.0" y="0.0" width="68.333333333333329" height="39.666666666666664"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="68.333333333333329" height="45"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tRW-pU-vRm">
-                                                        <rect key="frame" x="93.333333333333343" y="0.0" width="259.66666666666663" height="39.666666666666664"/>
+                                                        <rect key="frame" x="93.333333333333343" y="0.0" width="259.66666666666663" height="45"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" textContentType="country-name"/>
                                                     </textField>
@@ -355,13 +355,13 @@
                                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="City" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BQ5-d4-4u4">
-                                                        <rect key="frame" x="0.0" y="0.0" width="30.333333333333332" height="40"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="30.333333333333332" height="45.333333333333336"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZLA-Wu-FZ9">
-                                                        <rect key="frame" x="93.333333333333343" y="0.0" width="259.66666666666663" height="40"/>
+                                                        <rect key="frame" x="93.333333333333343" y="0.0" width="259.66666666666663" height="45.333333333333336"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <textInputTraits key="textInputTraits" textContentType="address-level2"/>
                                                     </textField>
@@ -374,23 +374,18 @@
                                         </constraints>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OzT-zU-7gG" userLabel="Buttons View">
-                                        <rect key="frame" x="0.0" y="358" width="353" height="76.666666666666686"/>
+                                        <rect key="frame" x="0.0" y="384.66666666666669" width="353" height="50"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="500" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" distribution="fillProportionally" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="Tu6-gA-jOx" userLabel="Buttons Stack View">
-                                                <rect key="frame" x="123.66666666666666" y="0.0" width="105.66666666666666" height="76.666666666666671"/>
+                                                <rect key="frame" x="123.66666666666666" y="0.0" width="105.66666666666666" height="50"/>
                                                 <subviews>
                                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nzh-FD-NEd">
-                                                        <rect key="frame" x="0.0" y="0.0" width="105.66666666666667" height="34.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="105.66666666666667" height="50"/>
                                                         <state key="normal" title="Button"/>
                                                         <buttonConfiguration key="configuration" style="filled" title="Sign Up"/>
                                                         <connections>
                                                             <action selector="signUpPressed:" destination="qvO-Ew-1SQ" eventType="touchUpInside" id="3cX-J7-d2h"/>
                                                         </connections>
-                                                    </button>
-                                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yht-mC-UQN">
-                                                        <rect key="frame" x="0.0" y="42.333333333333371" width="105.66666666666667" height="34.333333333333343"/>
-                                                        <state key="normal" title="Button"/>
-                                                        <buttonConfiguration key="configuration" style="filled" title="Sign Out"/>
                                                     </button>
                                                 </subviews>
                                                 <variation key="heightClass=compact" axis="horizontal"/>

--- a/NativeAuthSampleApp/Base.lproj/Main.storyboard
+++ b/NativeAuthSampleApp/Base.lproj/Main.storyboard
@@ -3,7 +3,7 @@
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -345,7 +345,7 @@
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tRW-pU-vRm">
                                                         <rect key="frame" x="93.333333333333343" y="0.0" width="259.66666666666663" height="39.666666666666664"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits" textContentType="address-level2"/>
+                                                        <textInputTraits key="textInputTraits" textContentType="country-name"/>
                                                     </textField>
                                                 </subviews>
                                                 <viewLayoutGuide key="safeArea" id="Oqo-hQ-M1H"/>
@@ -363,7 +363,7 @@
                                                     <textField opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="248" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZLA-Wu-FZ9">
                                                         <rect key="frame" x="93.333333333333343" y="0.0" width="259.66666666666663" height="40"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
+                                                        <textInputTraits key="textInputTraits" textContentType="address-level2"/>
                                                     </textField>
                                                 </subviews>
                                                 <viewLayoutGuide key="safeArea" id="5q9-gl-nia"/>
@@ -441,7 +441,6 @@
                         <outlet property="emailTextField" destination="bcI-75-H9s" id="dIW-OL-AUc"/>
                         <outlet property="passwordTextField" destination="jRP-EZ-IgC" id="u7S-gy-3C6"/>
                         <outlet property="resultTextView" destination="bYT-qv-DSC" id="kwc-y2-lZx"/>
-                        <outlet property="signOutButton" destination="Yht-mC-UQN" id="guh-7k-mF1"/>
                         <outlet property="signUpButton" destination="nzh-FD-NEd" id="MX8-JQ-Blz"/>
                     </connections>
                 </viewController>
@@ -1244,7 +1243,7 @@
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="systemRedColor">
-            <color red="1" green="0.23137254900000001" blue="0.18823529410000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="1" green="0.23137254901960785" blue="0.18823529411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/NativeAuthSampleApp/CustomAttributesViewController.swift
+++ b/NativeAuthSampleApp/CustomAttributesViewController.swift
@@ -57,6 +57,8 @@ class CustomAttributesViewController: UIViewController {
     }
 
     @IBAction func signUpPressed(_: Any) {
+        view.endEditing(true)
+
         guard let email = emailTextField.text, !email.isEmpty,
               let password = passwordTextField.text, !password.isEmpty
         else {

--- a/NativeAuthSampleApp/CustomAttributesViewController.swift
+++ b/NativeAuthSampleApp/CustomAttributesViewController.swift
@@ -35,7 +35,6 @@ class CustomAttributesViewController: UIViewController {
     @IBOutlet weak var resultTextView: UITextView!
 
     @IBOutlet weak var signUpButton: UIButton!
-    @IBOutlet weak var signOutButton: UIButton!
 
     var nativeAuth: MSALNativeAuthPublicClientApplication!
 

--- a/NativeAuthSampleApp/EmailAndCodeViewController.swift
+++ b/NativeAuthSampleApp/EmailAndCodeViewController.swift
@@ -62,6 +62,8 @@ class EmailAndCodeViewController: UIViewController {
     }
 
     @IBAction func signUpPressed(_: Any) {
+        emailTextField.resignFirstResponder()
+
         guard let email = emailTextField.text else {
             resultTextView.text = "Email not set"
             return
@@ -75,6 +77,8 @@ class EmailAndCodeViewController: UIViewController {
     }
 
     @IBAction func signInPressed(_: Any) {
+        emailTextField.resignFirstResponder()
+
         guard let email = emailTextField.text else {
             resultTextView.text = "email not set"
             return
@@ -88,6 +92,8 @@ class EmailAndCodeViewController: UIViewController {
     }
 
     @IBAction func signOutPressed(_: Any) {
+        emailTextField.resignFirstResponder()
+
         guard accountResult != nil else {
             print("signOutPressed: Not currently signed in")
             return

--- a/NativeAuthSampleApp/EmailAndPasswordViewController.swift
+++ b/NativeAuthSampleApp/EmailAndPasswordViewController.swift
@@ -62,6 +62,8 @@ class EmailAndPasswordViewController: UIViewController {
     }
 
     @IBAction func signUpPressed(_: Any) {
+        view.endEditing(true)
+
         guard let email = emailTextField.text, let password = passwordTextField.text else {
             resultTextView.text = "Email or password not set"
             return
@@ -75,6 +77,8 @@ class EmailAndPasswordViewController: UIViewController {
     }
 
     @IBAction func signInPressed(_: Any) {
+        view.endEditing(true)
+
         guard let email = emailTextField.text, let password = passwordTextField.text else {
             resultTextView.text = "Email or password not set"
             return
@@ -88,6 +92,8 @@ class EmailAndPasswordViewController: UIViewController {
     }
 
     @IBAction func signOutPressed(_: Any) {
+        view.endEditing(true)
+        
         guard accountResult != nil else {
             print("signOutPressed: Not currently signed in")
             return
@@ -357,6 +363,5 @@ extension EmailAndPasswordViewController {
 
         dismiss(animated: true)
         verifyCodeViewController = nil
-
     }
 }

--- a/NativeAuthSampleApp/NewPasswordViewController.swift
+++ b/NativeAuthSampleApp/NewPasswordViewController.swift
@@ -32,6 +32,7 @@ class NewPasswordViewController: UIViewController {
     @IBOutlet weak var passwordTextField: UITextField!
 
     @IBAction func cancelPressed(_: Any) {
+        passwordTextField.resignFirstResponder()
         onCancel?()
         
         dismiss(animated: true)
@@ -42,6 +43,7 @@ class NewPasswordViewController: UIViewController {
             return
         }
 
+        passwordTextField.resignFirstResponder()
         onSubmit?(password)
     }
 }

--- a/NativeAuthSampleApp/ObjCViewController.m
+++ b/NativeAuthSampleApp/ObjCViewController.m
@@ -127,7 +127,7 @@
 
 #pragma mark -  Credentials Delegate methods
 
-- (void)onAccessTokenRetrieveCompletedWithAccessToken:(MSALNativeAuthTokenResult *)result {
+- (void)onAccessTokenRetrieveCompletedWithResult:(MSALNativeAuthTokenResult *)result {
     [self showResultText:[NSString stringWithFormat:@"Signed in successfully. Access Token: %@", result.accessToken]];
     [self updateUI];
 }

--- a/NativeAuthSampleApp/ObjCViewController.m
+++ b/NativeAuthSampleApp/ObjCViewController.m
@@ -63,6 +63,8 @@
 }
 
 - (IBAction)signInPressed:(id)sender {
+    [self.view endEditing:YES];
+
     NSString *email = self.emailTextField.text;
     NSString *password = self.passwordTextField.text;
 
@@ -76,6 +78,8 @@
 }
 
 - (IBAction)signOutPressed:(id)sender {
+    [self.view endEditing:YES];
+
     if (self.accountResult == nil) {
         NSLog(@"signOutPressed: Not currently signed in.");
         return;

--- a/NativeAuthSampleApp/ProtectedAPIViewController.swift
+++ b/NativeAuthSampleApp/ProtectedAPIViewController.swift
@@ -77,6 +77,8 @@ class ProtectedAPIViewController: UIViewController {
     }
 
     @IBAction func signInPressed(_: Any) {
+        view.endEditing(true)
+
         guard let email = emailTextField.text, let password = passwordTextField.text else {
             resultTextView.text = "Email or password not set"
             return
@@ -90,6 +92,8 @@ class ProtectedAPIViewController: UIViewController {
     }
 
     @IBAction func signOutPressed(_: Any) {
+        view.endEditing(true)
+
         guard accountResult != nil else {
             print("signOutPressed: Not currently signed in")
             return
@@ -105,6 +109,8 @@ class ProtectedAPIViewController: UIViewController {
     }
     
     @IBAction func protectedApi1Pressed(_: Any) {
+        view.endEditing(true)
+
         guard let url = protectedAPIUrl1, !protectedAPIScopes1.isEmpty else {
             showResultText("API 1 not configured.")
             return
@@ -121,6 +127,8 @@ class ProtectedAPIViewController: UIViewController {
     }
     
     @IBAction func protectedApi2Pressed(_: Any) {
+        view.endEditing(true)
+
         guard let url = protectedAPIUrl2, !protectedAPIScopes2.isEmpty else {
             showResultText("API 2 not configured.")
             return

--- a/NativeAuthSampleApp/ResetPasswordViewController.swift
+++ b/NativeAuthSampleApp/ResetPasswordViewController.swift
@@ -61,6 +61,8 @@ class ResetPasswordViewController: UIViewController {
     }
 
     @IBAction func resetPasswordPressed(_: Any) {
+        emailTextField.resignFirstResponder()
+
         guard let email = emailTextField.text, !email.isEmpty
         else {
             resultTextView.text = "Invalid email address"
@@ -75,6 +77,8 @@ class ResetPasswordViewController: UIViewController {
     }
 
     @IBAction func signOutPressed(_: Any) {
+        emailTextField.resignFirstResponder()
+
         guard accountResult != nil else {
             print("signOutPressed: Not currently signed in")
             return

--- a/NativeAuthSampleApp/VerifyCodeViewController.swift
+++ b/NativeAuthSampleApp/VerifyCodeViewController.swift
@@ -32,10 +32,12 @@ class VerifyCodeViewController: UIViewController {
     @IBOutlet weak var codeTextField: UITextField!
 
     @IBAction func resendPressed(_: Any) {
+        codeTextField.resignFirstResponder()
         onResend?()
     }
 
     @IBAction func cancelPressed(_: Any) {
+        codeTextField.resignFirstResponder()
         onCancel?()
         
         dismiss(animated: true)
@@ -46,6 +48,7 @@ class VerifyCodeViewController: UIViewController {
             return
         }
 
+        codeTextField.resignFirstResponder()
         onSubmit?(code)
     }
 }

--- a/NativeAuthSampleApp/WebFallbackViewController.swift
+++ b/NativeAuthSampleApp/WebFallbackViewController.swift
@@ -57,6 +57,8 @@ class WebFallbackViewController: UIViewController {
     }
 
     @IBAction func signInPressed(_: Any) {
+        view.endEditing(true)
+
         guard let email = emailTextField.text, !email.isEmpty,
               let password = passwordTextField.text, !password.isEmpty
         else {
@@ -72,6 +74,8 @@ class WebFallbackViewController: UIViewController {
     }
 
     @IBAction func signOutPressed(_: Any) {
+        view.endEditing(true)
+
         if msalAccount != nil {
             signOutWithWebUX()
         } else if accountResult != nil {


### PR DESCRIPTION
## Purpose

List of issues solved:

- Whenever the user has the keyboard open and taps on a button, the keyboard is now hidden. In the ViewControllers that have only one TextField, `textField.resignFirstResponder()` is called; in those where there are two TextFields, `view.endEditing(true)` is called.
- Remove SignOut button from CustomAttributesViewController because it wasn't used.
- Fix the content type of the keyboard for the TextFields to introduce Country and City in CustomAttributesViewController.
- Fix the delegate method that is called in the ObjViewController.

Here is a video (it first shows "cancel", then "resend", then "submit"):

https://github.com/user-attachments/assets/bb67f8de-9f04-4d95-9def-65a2fd39f8d5

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```