### PR TITLE
Fix build error by upgrading MSAL to 2.7.0

### DIFF
--- a/NativeAuthSampleApp.xcodeproj/project.pbxproj
+++ b/NativeAuthSampleApp.xcodeproj/project.pbxproj
@@ -487,7 +487,7 @@
 			repositoryURL = "https://github.com/AzureAD/microsoft-authentication-library-for-objc";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.5.0;
+				minimumVersion = 2.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/NativeAuthSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NativeAuthSampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/AzureAD/microsoft-authentication-library-for-objc",
       "state" : {
-        "revision" : "6640c149b89bacce0013f8f584560b19f2cf772f",
-        "version" : "2.5.0"
+        "revision" : "09c275ada2236a834b981f6a4d5ecb491b576d6c",
+        "version" : "2.7.0"
       }
     }
   ],


### PR DESCRIPTION
## Purpose

Build fails with `Value of type 'MSALInteractiveTokenParameters' has no member 'domainHint'` in `WebFallbackViewController.swift`. Upgrading MSAL package to 2.7.0 resolves the missing member issue.

## Does this introduce a breaking change?

```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone git@github.com:k435467/ms-identity-ciam-native-auth-ios-sample.git
cd ms-identity-ciam-native-auth-ios-sample
git checkout fix/msal-version-ios-build-error
```

* Test the code
Open and run the project with Xcode.

## What to Check
Verify that the following are valid

1. The project compiles successfully without any MSAL-related member errors.
2. The `domainHint` property in `WebFallbackViewController.swift` is correctly recognized by the compiler.

## Other Information

This fix is essential for users following the official Entra ID native authentication tutorial, as the current sample code fails to build out-of-the-box due to the version mismatch.